### PR TITLE
Comm manager

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,4 +30,4 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: poetry run pytest --reruns 5 -s --log-level DEBUG
+        run: poetry run pytest --reruns 5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest
+        env:
+          IPYKERNEL_TEST_CONNECTION_FILE: /tmp/kernel.json
 
       - name: Kill Ipykernel
         run: kill $(cat /tmp/kernel.pid)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,3 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest --reruns 5 -s --log-level DEBUG
-
-
-      - name: Kill Ipykernel
-        run: kill $(cat /tmp/kernel.pid)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install Poetry
         shell: bash
-        run: curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.2.2 python3 -
+        run: curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.0 python3 -
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
           echo $! > /tmp/kernel.pid
 
       - name: Run tests
-        run: poetry run pytest --reruns 5 --timeout 10
+        run: poetry run pytest --reruns 5 -s --log-level DEBUG
         # env:
         #   IPYKERNEL_TEST_CONNECTION_FILE: /tmp/kernel.json
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Run tests
         run: poetry run pytest --reruns 5 --timeout 10
-        env:
-          IPYKERNEL_TEST_CONNECTION_FILE: /tmp/kernel.json
+        # env:
+        #   IPYKERNEL_TEST_CONNECTION_FILE: /tmp/kernel.json
 
       - name: Kill Ipykernel
         run: kill $(cat /tmp/kernel.pid)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,10 +32,11 @@ jobs:
       - name: Run Ipykernel
         run: |
           poetry run python -m ipykernel_launcher -f /tmp/kernel.json &
+          sleep 1
           echo $! > /tmp/kernel.pid
 
       - name: Run tests
-        run: poetry run pytest
+        run: poetry run pytest --reruns 5 --timeout 10
         env:
           IPYKERNEL_TEST_CONNECTION_FILE: /tmp/kernel.json
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,5 +26,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'poetry'
 
-      - run: poetry install
-      - run: poetry run pytest
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run Ipykernel
+        run: |
+          poetry run python -m ipykernel_launcher -f /tmp/kernel.json &
+          echo $! > /tmp/kernel.pid
+
+      - name: Run tests
+        run: poetry run pytest
+
+      - name: Kill Ipykernel
+        run: kill $(cat /tmp/kernel.pid)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,16 +29,9 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
-      - name: Run Ipykernel
-        run: |
-          poetry run python -m ipykernel_launcher -f /tmp/kernel.json &
-          sleep 1
-          echo $! > /tmp/kernel.pid
-
       - name: Run tests
         run: poetry run pytest --reruns 5 -s --log-level DEBUG
-        # env:
-        #   IPYKERNEL_TEST_CONNECTION_FILE: /tmp/kernel.json
+
 
       - name: Kill Ipykernel
         run: kill $(cat /tmp/kernel.pid)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## [0.3.1] - 2023-03-02
+
+### Added
+- Default handlers that can be attached to every Action created from `kernel.send`
+- Comm Manager that is attached to every Action in `kernel.send`
+  
 ## [0.3.0] - 2023-02-24
 
 ### Changed

--- a/poetry.lock
+++ b/poetry.lock
@@ -1282,17 +1282,6 @@ packaging = ">=17.1"
 pytest = ">=5.3"
 
 [[package]]
-name = "pytest-timeout"
-version = "2.1.0"
-description = "pytest plugin to abort hanging tests"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-pytest = ">=5.0.0"
-
-[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1664,7 +1653,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f57297fb88308f6ce66c83a17dbdd395e10b58a161219a4a3e63744424ca4145"
+content-hash = "de97d9f10505c29c03be5384a3c29c357650a80cfb06a231660c0e852e809272"
 
 [metadata.files]
 aiofiles = [
@@ -2363,10 +2352,6 @@ pytest-asyncio = [
 pytest-rerunfailures = [
     {file = "pytest-rerunfailures-11.1.1.tar.gz", hash = "sha256:acab447edff7c29a76b8410207c48da01406a161653c99a325cf5703d44eb162"},
     {file = "pytest_rerunfailures-11.1.1-py3-none-any.whl", hash = "sha256:4333983de0914f79d942a6ec29332f2c9cfe2d2d47ba2b634f3617b7f9d94f86"},
-]
-pytest-timeout = [
-    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
-    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1270,6 +1270,29 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "11.1.1"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+packaging = ">=17.1"
+pytest = ">=5.3"
+
+[[package]]
+name = "pytest-timeout"
+version = "2.1.0"
+description = "pytest plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pytest = ">=5.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1641,7 +1664,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d7871e5e7df9ebef6865dbf395d135889db40590b16f5a45fa72d906f8c5d5e2"
+content-hash = "f57297fb88308f6ce66c83a17dbdd395e10b58a161219a4a3e63744424ca4145"
 
 [metadata.files]
 aiofiles = [
@@ -2336,6 +2359,14 @@ pytest = [
 pytest-asyncio = [
     {file = "pytest-asyncio-0.20.3.tar.gz", hash = "sha256:83cbf01169ce3e8eb71c6c278ccb0574d1a7a3bb8eaaf5e50e0ad342afb33b36"},
     {file = "pytest_asyncio-0.20.3-py3-none-any.whl", hash = "sha256:f129998b209d04fcc65c96fc85c11e5316738358909a8399e93be553d7656442"},
+]
+pytest-rerunfailures = [
+    {file = "pytest-rerunfailures-11.1.1.tar.gz", hash = "sha256:acab447edff7c29a76b8410207c48da01406a161653c99a325cf5703d44eb162"},
+    {file = "pytest_rerunfailures-11.1.1-py3-none-any.whl", hash = "sha256:4333983de0914f79d942a6ec29332f2c9cfe2d2d47ba2b634f3617b7f9d94f86"},
+]
+pytest-timeout = [
+    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
+    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kernel-sidecar"
-version = "0.3.0"
+version = "0.3.1"
 description = "A sidecar "
 authors = ["Matt Kafonek <matt.kafonek@noteable.io>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ notebook = "^6.5.2"
 ipywidgets = "^8.0.4"
 jupyterlab = "^3.6.1"
 structlog = "^22.3.0"
+pytest-rerunfailures = "^11.1.1"
+pytest-timeout = "^2.1.0"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ ipywidgets = "^8.0.4"
 jupyterlab = "^3.6.1"
 structlog = "^22.3.0"
 pytest-rerunfailures = "^11.1.1"
-pytest-timeout = "^2.1.0"
 
 
 [tool.poetry.group.docs.dependencies]

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -23,13 +23,12 @@ import pydantic
 import zmq
 from jupyter_client import AsyncKernelClient, KernelConnectionInfo
 from jupyter_client.channels import ZMQSocketChannel
-from zmq.asyncio import Context
-from zmq.utils.monitor import recv_monitor_message
-
 from kernel_sidecar import actions
 from kernel_sidecar.comms import CommHandler, CommManager, CommOpenHandler, CommTargetNotFound
 from kernel_sidecar.handlers import Handler
 from kernel_sidecar.models import messages, requests
+from zmq.asyncio import Context
+from zmq.utils.monitor import recv_monitor_message
 
 logger = logging.getLogger(__name__)
 
@@ -407,19 +406,4 @@ class KernelSidecarClient:
             task.cancel()
         if self.mq_task:
             self.mq_task.cancel()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
-        self.kc.stop_channels()
         self.kc.stop_channels()

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -1,25 +1,35 @@
 """
+The KernelSidecarClient manages sending and receiving messages over zmq, and keeping track of
+"Actions" that it uses to delegate received messages to appropriate handlers.
+
 Use:
 
-async with kernel_sidecar.Kernel(connection_info) as kernel:
-    action = kernel.kernel_info_request()
+from kernel_sidecar.client import KernelSidecarClient
+from kernel_sidecar.handlers import DebugHandler
+
+async with KernelSidecarClient(connection_info) as client:
+    handler = DebugHandler()
+    action = kernel.kernel_info_request(handlers=[handler]))
     await action
 
-print(action.content)
+assert handler.counts == {"status": 2, "kernel_info_reply": 1}
 """
 
 import asyncio
 import logging
-from typing import List, Optional
+from typing import Awaitable, Callable, List, Optional, Type
 
 import pydantic
 import zmq
 from jupyter_client import AsyncKernelClient, KernelConnectionInfo
 from jupyter_client.channels import ZMQSocketChannel
-from kernel_sidecar import actions
-from kernel_sidecar.models import messages, requests
 from zmq.asyncio import Context
 from zmq.utils.monitor import recv_monitor_message
+
+from kernel_sidecar import actions
+from kernel_sidecar.comms import CommHandler, CommManager, CommOpenHandler, CommTargetNotFound
+from kernel_sidecar.handlers import Handler
+from kernel_sidecar.models import messages, requests
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +43,8 @@ class KernelSidecarClient:
      - Parses messages coming from the Kernel into (`models.messages.py`) Pydantic models
      - Delegates handling those messages to the appropriate Action that started the request-reply
        sequence, and that Action should have Handlers / async fn callbacks to handle business logic
+     - Includes options for "default handlers" applied to all Actions, and a reference to the
+       CommManager, which will process and/or route comm_open, comm_msg, and comm_close messages
     """
 
     _message_model = messages.Message
@@ -45,6 +57,8 @@ class KernelSidecarClient:
         self,
         connection_info: KernelConnectionInfo,
         max_message_size: Optional[int] = None,
+        default_handlers: List[Handler] = None,
+        comm_manager: Optional[CommManager] = None,
     ):
         """
         - connection_info: dict with zmq ports the Kernel has open
@@ -52,17 +66,19 @@ class KernelSidecarClient:
           automatically close the socket if the message is over that size. Useful if the sidecar
           application has less memory than the Kernel and need to avoid OOM in sidecar from large
           outputs or other messages coming in from the Kernel
+        - default_handlers: appended to every Action's handler list when Action request is sent
         """
-        zmq_context = Context()
+        zmq_context = Context()  # only relevant if max_message_size is set
         if max_message_size:
             zmq_context.setsockopt(zmq.SocketOption.MAXMSGSIZE, max_message_size)
         self.kc = AsyncKernelClient(context=zmq_context)
         self.kc.load_connection_info(connection_info)
 
-        self.status: messages.KernelStatus = None
+        # Used to delegate received messages to handlers attached to the Action
+        # When we send a request to the kernel, we use the request msg_id {msg_id: Action}
+        # When we receive messages from kernel, we look up the Action by the parent_header.msg_id
+        # and delegate the messages to handlers attached to that Action
         self.actions: dict[str, actions.KernelAction] = {}
-
-        self.kc.start_channels()
 
         # message queue, raw data (dict) from all zmq channels gets dropped into here
         # and a separate asyncio.Task picks them up off the queue to pass into the
@@ -73,6 +89,15 @@ class KernelSidecarClient:
         self.mq_task: asyncio.Task = None
         self.channel_watching_tasks: List[asyncio.Task] = []
         self.channel_watcher_parent_tasks: List[asyncio.Task] = []
+
+        # Handlers to attach to every Action. These will be appended to action.handlers
+        # during .send, which means they'll run /after/ other handlers.
+        # Fail right away if there's common mistake of init'ing with default_handlers=Handler()
+        if default_handlers and not isinstance(default_handlers, list):
+            raise RuntimeError(f"{default_handlers=} must be None or a list")
+        self.default_handlers = default_handlers or []
+
+        self.comm_manager = comm_manager or CommManager()
 
     @property
     def running_action(self):
@@ -94,6 +119,12 @@ class KernelSidecarClient:
         if action.msg_id in self.actions:
             raise RuntimeError(f"Already tracking reply routing for {action.msg_id=}")
 
+        # Reminder: when messages are processed, they get sent to each Action handler in order so
+        # default handlers will run /after/ handlers already attached to this Action and the
+        # CommManager handler will run last
+        action.handlers.extend(self.default_handlers)
+        action.handlers.append(self.comm_manager)
+
         # Send the request over the appropriate zmq channel
         try:
             channel: ZMQSocketChannel = getattr(self.kc, f"{action.request._channel}_channel")
@@ -109,14 +140,14 @@ class KernelSidecarClient:
         return action
 
     def kernel_info_request(
-        self, handlers: List[actions.HandlerType] = None
+        self, handlers: List[Callable[[messages.Message], Awaitable[None]]] = None
     ) -> actions.KernelAction:
         req = requests.KernelInfoRequest()
         action = actions.KernelAction(request=req, handlers=handlers)
         return self.send(action)
 
     def execute_request(
-        self, code: str, silent: bool = False, handlers: List[actions.HandlerType] = None
+        self, code: str, silent: bool = False, handlers: List[Handler] = None
     ) -> actions.KernelAction:
         req = requests.ExecuteRequest(content={"code": code, "silent": silent})
         action = actions.KernelAction(request=req, handlers=handlers)
@@ -126,7 +157,7 @@ class KernelSidecarClient:
         self,
         code: str,
         cursor_pos: Optional[int] = None,
-        handlers: List[actions.HandlerType] = None,
+        handlers: List[Handler] = None,
     ) -> actions.KernelAction:
         if cursor_pos is None:
             cursor_pos = len(code)
@@ -134,16 +165,43 @@ class KernelSidecarClient:
         action = actions.KernelAction(request=req, handlers=handlers)
         return self.send(action)
 
-    def interrupt_request(self, handlers: List[actions.HandlerType] = None) -> actions.KernelAction:
+    def interrupt_request(self, handlers: List[Handler] = None) -> actions.KernelAction:
         req = requests.InterruptRequest()
         action = actions.KernelAction(request=req, handlers=handlers)
         return self.send(action)
+
+    async def comm_open(
+        self, target_name: str, handler_cls: Type[CommHandler], data: Optional[dict] = None
+    ) -> CommHandler:
+        """
+        High level helper for opening a comm from the sidecar side. If there's no comm handling
+        function registered on the kernel for the given target_name, the kernel will send out
+        a stream message with stderr and a comm_close event, which we'll raise here.
+        """
+        # think of this handler as an ephemeral handler just here so we can raise an error if the
+        # kernel reports that the comm target is not found
+        msg_handler = CommOpenHandler()
+        # Create Action and send comm_open over zmq
+        action = self.comm_open_request(target_name, data, handlers=[msg_handler])
+        # pull out comm_id from the request
+        req: requests.CommOpen = action.request
+        comm_id = req.content.comm_id
+        # Register the CommHandler in the CommManager before awaiting the Action, so CommManager
+        # can observe any comm_msg during the open process and delegate to CommHandler.
+        # If there's an error, comm_manager will deregister while handling comm_close msg
+        comm_handler = handler_cls(comm_id=comm_id)
+        self.comm_manager.comms[comm_id] = comm_handler
+        logger.debug("registered comm", extra={"comm_id": comm_id, "handler": comm_handler})
+        await action
+        if msg_handler.comm_closed_id == comm_id:
+            raise CommTargetNotFound(msg_handler.comm_err_msg)
+        return comm_handler
 
     def comm_open_request(
         self,
         target_name: str,
         data: Optional[dict] = None,
-        handlers: List[actions.HandlerType] = None,
+        handlers: List[Handler] = None,
     ) -> actions.KernelAction:
         if data is None:
             data = {}
@@ -155,14 +213,14 @@ class KernelSidecarClient:
         self,
         comm_id: str,
         data: Optional[dict] = None,
-        handlers: List[actions.HandlerType] = None,
+        handlers: List[Handler] = None,
     ) -> actions.KernelAction:
         req = requests.CommMsg(content={"comm_id": comm_id, "data": data})
         action = actions.KernelAction(request=req, handlers=handlers)
         return self.send(action)
 
     def comm_close_request(
-        self, comm_id: str, handlers: List[actions.HandlerType] = None
+        self, comm_id: str, handlers: List[Handler] = None
     ) -> actions.KernelAction:
         req = requests.CommClose(content={"comm_id": comm_id})
         action = actions.KernelAction(request=req, handlers=handlers)
@@ -195,7 +253,7 @@ class KernelSidecarClient:
         logger.debug("Channel watcher started", extra={"channel": channel_name})
         channel: ZMQSocketChannel = getattr(self.kc, f"{channel_name}_channel")
 
-        message_task = asyncio.create_task(self._watch_channel_for_messages(channel))
+        message_task = asyncio.create_task(self._watch_channel_for_messages(channel, channel_name))
         status_task = asyncio.create_task(
             self._watch_channel_for_status(channel.socket.get_monitor_socket())
         )
@@ -250,7 +308,7 @@ class KernelSidecarClient:
             except asyncio.CancelledError:
                 break
 
-    async def _watch_channel_for_messages(self, channel: ZMQSocketChannel):
+    async def _watch_channel_for_messages(self, channel: ZMQSocketChannel, channel_name: str):
         """Takes messages seen on zmq and drops them into our internal asyncio.Queue"""
         while True:
             try:
@@ -258,7 +316,11 @@ class KernelSidecarClient:
                     await asyncio.sleep(0.001)
                     continue
                 raw_msg: dict = await channel.get_msg()
-                logger.debug("Message received on zmq", extra={"body": raw_msg})
+                msg_type = raw_msg.get("msg_type", "")
+                logger.debug(
+                    f"Message {msg_type} on {channel_name}",
+                    extra={"body": raw_msg, "channel": channel_name},
+                )
                 self.mq.put_nowait(raw_msg)
             except asyncio.CancelledError:
                 break
@@ -345,4 +407,19 @@ class KernelSidecarClient:
             task.cancel()
         if self.mq_task:
             self.mq_task.cancel()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
+        self.kc.stop_channels()
         self.kc.stop_channels()

--- a/src/kernel_sidecar/comms.py
+++ b/src/kernel_sidecar/comms.py
@@ -1,18 +1,118 @@
 """
-Comm Manager and Comm Handlers
+Comms are a flexible way for the Kernel and clients (historically frontends in our case the sidecar)
+to communicate, particularly when the Kernel wants to trigger some action on the frontend. The
+ipywidgets library is probably the most well known use of Comms in Jupyter. When a widget is created
+(via execute_request), it opens three comms. If something on the kernel side changes the layout,
+style, or value of the widget, the Kernel can emit comm_msg for those comm_id's to tell frontend
+to update how it renders the widgets. If the user interacts with the widget, the frontend emits
+comm_msg's to the Kernel to tell it to update the widget state.
+
+Within kernel-sidecar, Comms are a bit tricky because they don't fit in with the other "Action"
+request-reply handler paradigm. An execute_request might cause comm_msg's to be emitted, or sending
+a comm_msg request might get comm_msg's in the replies. The way we handle this is to attach a single
+CommManager Handler to every Action that is sent. CommManager will handle comm_* messages seen in
+any request type. It can then delegate comm_msg's to appropriate CommHandler instances based on the
+comm_id seen in the comm_msg.content.
 """
-from typing import Dict
+import logging
+from typing import Dict, Type, Union
+
 from kernel_sidecar.handlers import Handler
+from kernel_sidecar.models import messages
+
+logger = logging.getLogger(__name__)
 
 
 class CommHandler(Handler):
-    def __init__(self, target_name: str, comm_id: str):
-        self.target_name = target_name
+    def __init__(self, comm_id: str):
         self.comm_id = comm_id
 
+    def __repr__(self):
+        return f"{self.__class__.__name__} ({self.comm_id})"
 
-class CommManager:
-    _target_name_to_handler_cls = {}
-    
-    def __init__(self, target_name_to_handler_cls: Dict[str, CommHandler] = {}):
-        self.comms = {}
+
+class CommManager(Handler):
+    def __init__(self, handlers: Dict[str, Type[CommHandler]] = None):
+        self.comms: Dict[str, CommHandler] = {}  # keys are comm_id, values are CommHandler instance
+        self.handlers = handlers or {}  # keys are target_name, values are CommHandler class
+
+    async def handle_comm_open(self, msg: messages.CommOpen):
+        """
+        Every comm_open has a comm_id, target_name, and optional data. From the managers perspective
+        we need to map {comm_id: handler} based on a lookup of {target_name: handler} so that when
+        we see comm_msg in the future, which only guarentee comm_id not target_name, we can route
+        messages to the appropriate handler
+        """
+        comm_id = msg.content.comm_id
+        target_name = msg.content.target_name
+        if comm_id in self.comms:
+            # Seems like a weird situation if we see a second comm open for the same comm_id?
+            # Don't think it's technically against the spec.
+            handler = self.comms[comm_id]
+        else:
+            if target_name not in self.handlers:
+                return await self.handle_unrecognized_comm_target(msg)
+            handler_cls = self.handlers[target_name]
+            handler = handler_cls(comm_id=comm_id)
+            self.comms[comm_id] = handler
+            logger.debug("registered comm", extra={"comm_id": comm_id, "handler": handler})
+        await handler(msg)
+
+    async def handle_comm_msg(self, msg: messages.CommMsg):
+        comm_id = msg.content.comm_id
+        if comm_id not in self.comms:
+            return await self.handle_unrecognized_comm_id(msg)
+        handler = self.comms[comm_id]
+        await handler(msg)
+
+    async def handle_comm_close(self, msg: messages.CommClose):
+        comm_id = msg.content.comm_id
+        if comm_id not in self.comms:
+            return await self.handle_unrecognized_comm_id(msg)
+        handler = self.comms[comm_id]
+        await handler(msg)
+        del self.comms[comm_id]
+
+    async def handle_unrecognized_comm_target(self, msg: messages.CommOpen):
+        """
+        Drop into here when we observe a comm_open with a target_name that we don't have mapped to
+        a handler class. If you have a "catch-all" handler, this is a good place to set that up.
+
+        E.g.
+        self.handlers[msg.content.target_name] = MyCatchAllHandler
+        return await self.handle_comm_open(msg)
+        """
+        pass
+
+    async def handle_unrecognized_comm_id(self, msg: Union[messages.CommMsg, messages.CommClose]):
+        """
+        If we're seeing comm_msg or comm_close with a comm_id we aren't storing, then it's likely
+        either another client is talking to the kernel (bad) or there was a comm_open earlier with
+        a target_name we didn't have a handler mapped for, so now we have comm_msg's we're just not
+        handling.
+        """
+        logger.debug("unrecognized comm_id", extra={"comm_id": msg.content.comm_id})
+        pass
+
+
+class CommTargetNotFound(Exception):
+    pass
+
+
+class CommOpenHandler(Handler):
+    """
+    Used when sending a comm_open request from sidecar to kernel. If there is no Comm registered
+    for the target_name, the Kernel will say as much in a stream (stderr) reply, and send a
+    comm_close event.
+    """
+
+    def __init__(self):
+        self.comm_err_msg = None
+        self.comm_closed_id = None
+
+    async def handle_stream(self, msg: messages.Stream):
+        if msg.content.name == "stderr":
+            self.comm_err_msg = msg.content.text
+
+    async def handle_comm_close(self, msg: messages.CommClose):
+        self.comm_closed_id = msg.content.comm_id

--- a/src/kernel_sidecar/comms.py
+++ b/src/kernel_sidecar/comms.py
@@ -1,0 +1,18 @@
+"""
+Comm Manager and Comm Handlers
+"""
+from typing import Dict
+from kernel_sidecar.handlers import Handler
+
+
+class CommHandler(Handler):
+    def __init__(self, target_name: str, comm_id: str):
+        self.target_name = target_name
+        self.comm_id = comm_id
+
+
+class CommManager:
+    _target_name_to_handler_cls = {}
+    
+    def __init__(self, target_name_to_handler_cls: Dict[str, CommHandler] = {}):
+        self.comms = {}

--- a/src/kernel_sidecar/handlers.py
+++ b/src/kernel_sidecar/handlers.py
@@ -13,6 +13,9 @@ class Handler:
 
     action = kernel.kernel_info_request(handlers=[StatusHandler()])
     await action
+
+    >>> Kernel status: busy
+    >>> Kernel status: idle
     """
 
     async def __call__(self, msg: messages.Message):
@@ -37,11 +40,24 @@ class DebugHandler(Handler):
     action = kernel.kernel_info_request(handlers=[handler])
     await action
     assert handler.counts == {"status": 2, "kernel_info_reply": 1}
+
+    kernel_info_reply: messages.KernelInfoReply = handler.get_last_msg("kernel_info_reply")
+    assert kernel_info_reply.status == "ok"
     """
 
     def __init__(self):
         self.counts = collections.defaultdict(int)
+        # don't access this in tests like "last_msg = handler.last_msg_by_type['status']" becuse
+        # it will raise an obtuse error saying a typing.Union cannot be called. What's happening
+        # is that if the key is missing, defaultdict tries to instantiate a messages.Message which
+        # is a typing.Annotated[typing.Union]] (discriminator pattern) and everything blows up.
+        # use .get_last_msg() instead.
         self.last_msg_by_type = collections.defaultdict(messages.Message)
+
+    def get_last_msg(self, msg_type: str) -> messages.Message:
+        if msg_type not in self.last_msg_by_type:
+            raise KeyError(f"No message of type {msg_type} has been received")
+        return self.last_msg_by_type[msg_type]
 
     async def unhandled_message(self, msg: messages.Message):
         # effectively a catch-all for every message type since no other handlers are defined

--- a/tests/test_comms.py
+++ b/tests/test_comms.py
@@ -1,0 +1,256 @@
+import textwrap
+
+import pytest
+from kernel_sidecar.client import KernelSidecarClient
+from kernel_sidecar.comms import CommHandler, CommTargetNotFound
+from kernel_sidecar.handlers import DebugHandler
+from kernel_sidecar.models import messages
+
+
+class DebugCommHandler(CommHandler, DebugHandler):
+    """
+    DebugHandler / CommHandler mixin. Use:
+
+    (assuming 'foo' comm target_name is registered on kernel side and will echo comm_msg data back)
+
+    debug_comm_handler = await kernel.comm_open('foo')
+    action = kernel.comm_msg_request(debug_comm_handler.comm_id, data={"foo": "bar"})
+    assert debug_comm_handler.counts == {"comm_msg": 1}
+    assert debug_comm_handler.get_last_msg("comm_msg").content.data == {"foo": "bar"}
+    """
+
+    def __init__(self, comm_id: str):
+        CommHandler.__init__(self, comm_id)
+        DebugHandler.__init__(self)
+
+
+async def test_comm_target_not_found(kernel: KernelSidecarClient):
+    """
+    Show that if the kernel tries to open a comm without a comm being registered in the kernel by
+    target_name / comm_id, it will raise CommTargetNotFound
+    """
+    with pytest.raises(CommTargetNotFound):
+        await kernel.comm_open(target_name="foo", handler_cls=CommHandler)
+
+
+async def test_comm_happy_path(kernel: KernelSidecarClient):
+    """
+    This is the "normal" way we expect to use Comms in a sidecar application. A comm target is
+    registered on the Kernel side, but not opened yet. The reason this to do it this way is that
+    you'll get a direct reference to the CommHandler instance (with comm_id) in the sidecar compute
+    when opening from sidecar, and the syntax to send messages after that is simple.
+
+    If the comm is opened from the kernel side, we'll still have a CommHandler instance on the
+    sidecar side but would need some kind of logic to look it up in kernel.comm_manager.comms.
+    """
+    # register comm on kernel side first, it will emit a comm_msg on comm open
+    code = textwrap.dedent(
+        """
+    def comm_fn(comm, open_msg):
+        @comm.on_msg
+        def _recv(msg):
+            comm.send({"echo": msg["content"]["data"]})
+        
+        comm.send("connected")
+
+    get_ipython().kernel.comm_manager.register_target("test_comm", comm_fn)
+    """
+    )
+    await kernel.execute_request(code)
+
+    # - instantiates a DebugCommHandler class and registers it with the kernel.comm_manager
+    # - sends comm_open request to kernel and watches for errors during that request-reply
+    # - no errors since target_name is registered earlier, return DebugCommHandler instance
+    comm_handler: DebugCommHandler = await kernel.comm_open(
+        target_name="test_comm", handler_cls=DebugCommHandler
+    )
+    assert comm_handler.comm_id
+
+    assert comm_handler.counts == {"comm_msg": 1}
+    comm_msg: messages.CommMsg = comm_handler.get_last_msg("comm_msg")
+    assert comm_msg.content.data == "connected"
+
+    await kernel.comm_msg_request(comm_handler.comm_id, data={"foo": "bar"})
+    assert comm_handler.counts == {"comm_msg": 2}
+    comm_msg: messages.CommMsg = comm_handler.get_last_msg("comm_msg")
+    assert comm_msg.content.data == {"echo": {"foo": "bar"}}
+
+
+async def test_kernel_open_comm(kernel: KernelSidecarClient):
+    """
+    Show how to handle cases where the kernel opens comms, such as when you create an ipywidget
+    in the kernel. Usually these comm_open messages come in as replies to an execute_requset,
+    but they could be a side effect of handling a comm_msg or something else. Either way, the
+    kernel.comm_manager as a handler is attached to every request, so we don't need to worry about
+    catching the comm_open in explicit handlers attached to an action.
+
+    When comm_manager handler sees the comm_open, it checks its comm_manager.handlers dictionary
+    to see if it has a class for the comm_open's target_name. If so, instantiate it and add to
+    comm_manager.comms dictionary.
+
+    comm_* messages are delegated to the CommHandler instance, and also seen by any handlers
+    watching the execute_request request-reply action.
+    """
+    # "factory pattern" - register a class that will be instantiated when a comm_open comes in
+    # for the given target_name
+    kernel.comm_manager.handlers["test_comm"] = DebugCommHandler
+    # handler to watch replies just for this execute_request
+    msg_handler = DebugHandler()
+    code = textwrap.dedent(
+        """
+    from ipykernel.comm import Comm
+    comm = Comm(target_name="test_comm", data="connected")
+    comm.send({"hello": "world"})
+    comm.comm_id
+    """
+    )
+    action = kernel.execute_request(code, handlers=[msg_handler])
+    await action
+    assert msg_handler.counts == {
+        "status": 2,
+        "execute_input": 1,
+        "comm_open": 1,
+        "comm_msg": 1,
+        "execute_result": 1,
+        "execute_reply": 1,
+    }
+    execute_result: messages.ExecuteResult = msg_handler.get_last_msg("execute_result")
+    comm_id = execute_result.content.data["text/plain"].strip("'")
+
+    assert len(kernel.comm_manager.comms) == 1
+    comm_handler: DebugCommHandler = kernel.comm_manager.comms[comm_id]
+    assert comm_handler.counts == {"comm_open": 1, "comm_msg": 1}
+
+    comm_open: messages.CommOpen = comm_handler.get_last_msg("comm_open")
+    assert comm_open.content.data == "connected"
+
+    comm_msg: messages.CommMsg = comm_handler.get_last_msg("comm_msg")
+    assert comm_msg.content.data == {"hello": "world"}
+
+
+async def test_ipywidgets(kernel: KernelSidecarClient):
+    """
+    Show how to capture comm messages emitted by ipywidgets. Future work in kernel-sidecar might
+    add a default jupyter.widget CommHandler, but for now just show the counts of comm_open and
+    comm_msg's that are seen when creating, updating, and rendering an ipywidget kernel side.
+    """
+    kernel.comm_manager.handlers["jupyter.widget"] = DebugCommHandler
+    msg_handler = DebugHandler()
+    code = textwrap.dedent(
+        """
+    from ipywidgets import IntSlider
+    slider = IntSlider()
+    slider.value = 5
+    slider
+    """
+    )
+    action = kernel.execute_request(code, handlers=[msg_handler])
+    await action
+    assert msg_handler.counts == {
+        "status": 2,
+        "execute_input": 1,
+        "comm_open": 3,
+        "comm_msg": 1,
+        "execute_result": 1,
+        "execute_reply": 1,
+    }
+    execute_result: messages.ExecuteResult = msg_handler.get_last_msg("execute_result")
+    assert execute_result.content.data["text/plain"] == "IntSlider(value=5)"
+    # ipywidgets opens three comms: one for Layout, one for Style, and one for widget value
+    assert len(kernel.comm_manager.comms) == 3
+
+
+async def test_comm_msg_side_effects(kernel: KernelSidecarClient):
+    """
+    Highlight an edge case here that is not necessarily well handled in regular Jupyter / Lab,
+    what happens if a comm_msg function kernel side ends up emitting `stream` or other message
+    types? In kernel-sidecar, just show that we can still capture those with a handler attached
+    to the comm_msg request Action, while also guarenteeing any comm_msg automatically get caught
+    by comm_manager and delegated to our comm_handler.
+    """
+    # When we comm_open to target name test_comm, then send a comm_msg by comm_id afterwards,
+    # we should see a stream, update_display_data, and comm_msg back
+    code = textwrap.dedent(
+        """
+    from IPython.display import display
+
+    disp = display("foo", display_id=123)
+
+    def comm_fn(comm, open_msg):
+        @comm.on_msg
+        def _recv(msg):
+            print("test")
+            disp.update("bar")
+            comm.send({"echo": msg["content"]["data"]})
+
+    get_ipython().kernel.comm_manager.register_target("test_comm", comm_fn)
+    """
+    )
+    # register the comm kernel side
+    await kernel.execute_request(code)
+
+    # send comm_open and get our instantiated CommHandler
+    comm_handler: DebugCommHandler = await kernel.comm_open(
+        target_name="test_comm", handler_cls=DebugCommHandler
+    )
+
+    # now send comm_msg, attach DebugHandler explicitly to it. Assert we see messages on the
+    # DebugHandler, and that we also see messages in from comm_handler
+    comm_handler.counts.clear()  # reset counts, only want to assert what's seen after this comm_msg
+    msg_handler = DebugHandler()
+    action = kernel.comm_msg_request(
+        comm_id=comm_handler.comm_id, data={"foo": "bar"}, handlers=[msg_handler]
+    )
+    await action
+
+    assert msg_handler.counts == {
+        "status": 2,
+        "comm_msg": 1,
+        "stream": 1,
+        "update_display_data": 1,
+    }
+
+    assert comm_handler.counts == {"comm_msg": 1}
+    comm_msg: messages.CommMsg = comm_handler.get_last_msg("comm_msg")
+    assert comm_msg.content.data == {"echo": {"foo": "bar"}}
+
+
+async def test_inter_comm_msgs(kernel: KernelSidecarClient):
+    """
+    Show that if one Comm sends messages out to a different Comm, we end up routing those to the
+    right CommHandler's on the kernel side. In the test below, even though comm_handler1 sends
+    the comm_msg that is getting acted on, the kernel is emitting a comm_msg with the comm_id for
+    our comm_handler2, so we should only expect that comm_handler2 has received a message to handle.
+    """
+    # Set it up so that when a comm_msg is handled by one comm, it broadcasts that message to
+    # all other comms
+    code = textwrap.dedent(
+        """
+    all_comms = []
+    def comm_fn(comm, open_msg):
+        @comm.on_msg
+        def _recv(msg):
+            for other_comm in all_comms:
+                if other_comm.comm_id != comm.comm_id:
+                    other_comm.send({"broadcasting": msg["content"]["data"]})
+            
+
+        all_comms.append(comm)
+
+    get_ipython().kernel.comm_manager.register_target("test_comm", comm_fn)
+    """
+    )
+    await kernel.execute_request(code)
+
+    comm_handler1: DebugCommHandler = await kernel.comm_open(
+        target_name="test_comm", handler_cls=DebugCommHandler
+    )
+    comm_handler2: DebugCommHandler = await kernel.comm_open(
+        target_name="test_comm", handler_cls=DebugCommHandler
+    )
+
+    await kernel.comm_msg_request(comm_id=comm_handler1.comm_id, data={"foo": "bar"})
+    assert comm_handler1.counts == {}
+    assert comm_handler2.counts == {"comm_msg": 1}
+    comm_msg: messages.CommMsg = comm_handler2.get_last_msg("comm_msg")
+    assert comm_msg.content.data == {"broadcasting": {"foo": "bar"}}

--- a/tests/test_zmq_disconnect.py
+++ b/tests/test_zmq_disconnect.py
@@ -29,6 +29,7 @@ async def test_zmq_disconnect(ipykernel: dict):
     Show that a subclassed Kernel with zmq handling hooks takes action when zmq iopub channel
     gets disconnected because a message is larger than the max_message_size setting.
     """
+    kernel: DisconnectHandlingClient  # type hint here, can't hint while entering context manager
     async with DisconnectHandlingClient(connection_info=ipykernel, max_message_size=1024) as kernel:
         # A small stream output should come through fine
         handler = DebugHandler()


### PR DESCRIPTION
Add in Comm Manager concept. It's attached as a Handler for every Action so that we can factory-style spawn Handler instances on `comm_open` by `target_name`, and route `comm_msg` to appropriate handlers by `comm_msg.content.comm_id`.