### PR TITLE
Missing execute replies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,4 +30,4 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: poetry run pytest --reruns 5 -s --log-level DEBUG
+        run: poetry run pytest --reruns 5 --log-level DEBUG

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Install Poetry
         shell: bash
-        run: curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.0 python3 -
+        run: curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.4.1 python3 -
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,4 +30,4 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: poetry run pytest --reruns 5
+        run: poetry run pytest --reruns 5 --log-level DEBUG

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,4 +30,4 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: poetry run pytest --reruns 5 --log-level DEBUG
+        run: poetry run pytest --reruns 5 --log-level DEBUG -s

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,4 +30,4 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: poetry run pytest --reruns 5 --log-level DEBUG -s
+        run: poetry run pytest --reruns 5 --log-level DEBUG -s --setup-show

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,4 +30,4 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: poetry run pytest --reruns 5 --log-level DEBUG
+        run: poetry run pytest --reruns 5 -s --log-level DEBUG

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,4 +30,4 @@ jobs:
         run: poetry install
 
       - name: Run tests
-        run: poetry run pytest --reruns 5 --log-level DEBUG -s --setup-show
+        run: poetry run pytest --reruns 5 --log-level DEBUG --setup-show

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 ## [0.4.1] - 2023-03-22
 ### Changed
 - All Actions will treat seeing an `error` message as being the same as it's "complete reply" message (e.g. `execute_reply` for `execute_request` Actions)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## [0.4.1] - 2023-03-22
+### Changed
+- All Actions will treat seeing an `error` message as being the same as it's "complete reply" message (e.g. `execute_reply` for `execute_request` Actions)
+  - Hopefully fixes issues with CI, and possibly hard-to-debug edge cases that would pop up in applications. Never observed missing `execute_reply` in tests locally though
+
+### Fixed
+- Remove errant logs left over from 0.4.0 dev/release
 
 ## [0.4.0] - 2023-03-22
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kernel-sidecar"
-version = "0.4.0"
+version = "0.4.1"
 description = "A sidecar "
 authors = ["Matt Kafonek <matt.kafonek@noteable.io>"]
 readme = "README.md"

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -24,14 +24,15 @@ import pydantic
 import zmq
 from jupyter_client import AsyncKernelClient, KernelConnectionInfo
 from jupyter_client.channels import ZMQSocketChannel
+from zmq.asyncio import Context
+from zmq.utils.monitor import recv_monitor_message
+
 from kernel_sidecar import actions
 from kernel_sidecar.comms import CommHandler, CommManager, WidgetHandler
 from kernel_sidecar.handlers.base import Handler
 from kernel_sidecar.models import messages, requests
 from kernel_sidecar.models.notebook import Notebook
 from kernel_sidecar.nb_builder import NotebookBuilder
-from zmq.asyncio import Context
-from zmq.utils.monitor import recv_monitor_message
 
 logger = logging.getLogger(__name__)
 
@@ -453,4 +454,5 @@ class KernelSidecarClient:
             task.cancel()
         if self.mq_task:
             self.mq_task.cancel()
+        logger.critical("stopping channels while exiting KernelSidecarClient async context")
         self.kc.stop_channels()

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -24,15 +24,14 @@ import pydantic
 import zmq
 from jupyter_client import AsyncKernelClient, KernelConnectionInfo
 from jupyter_client.channels import ZMQSocketChannel
-from zmq.asyncio import Context
-from zmq.utils.monitor import recv_monitor_message
-
 from kernel_sidecar import actions
 from kernel_sidecar.comms import CommHandler, CommManager, WidgetHandler
 from kernel_sidecar.handlers.base import Handler
 from kernel_sidecar.models import messages, requests
 from kernel_sidecar.models.notebook import Notebook
 from kernel_sidecar.nb_builder import NotebookBuilder
+from zmq.asyncio import Context
+from zmq.utils.monitor import recv_monitor_message
 
 logger = logging.getLogger(__name__)
 
@@ -430,7 +429,7 @@ class KernelSidecarClient:
         )
 
     async def handle_zmq_disconnect(self, channel_name: str):
-        pass
+        logger.critical("ZMQ channel disconnected", extra={"channel": channel_name})
 
     async def __aenter__(self) -> "KernelSidecarClient":
         # General asyncio comment: make sure tasks always have a reference (assigned to variable or

--- a/src/kernel_sidecar/handlers/output.py
+++ b/src/kernel_sidecar/handlers/output.py
@@ -101,8 +101,8 @@ class OutputHandler(Handler):
                 # this means we are entering into the "with Output()" context manager
                 # all further output messages (stream, display_data, error) should be added
                 # to this Output widget .outputs instead of to the cell output
-                logger.critical("entering output widget context manager")
+                logger.debug("entering output widget context manager")
                 self.output_widget_contexts.insert(0, comm_handler)
             else:
-                logger.critical("exiting output widget context manager")
+                logger.debug("exiting output widget context manager")
                 self.output_widget_contexts.remove(comm_handler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,8 @@ async def kernel(ipykernel: dict) -> KernelSidecarClient:
         if log_level == logging.DEBUG:
             logging.getLogger("kernel_sidecar").setLevel(logging.INFO)
         logger.critical("Using reset magic to clear Kernel state")
-        await kernel.execute_request(code="%reset -f in out dhist")
+        action = kernel.execute_request(code="%reset -f in out dhist")
+        await asyncio.wait_for(action, timeout=1)
         if log_level == logging.DEBUG:
             logging.getLogger("kernel_sidecar").setLevel(log_level)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ async def kernel(ipykernel: dict) -> KernelSidecarClient:
         log_level = logging.getLogger("kernel_sidecar").getEffectiveLevel()
         if log_level == logging.DEBUG:
             logging.getLogger("kernel_sidecar").setLevel(logging.INFO)
+        logger.critical("Using reset magic to clear Kernel state")
         await kernel.execute_request(code="%reset -f in out dhist")
         if log_level == logging.DEBUG:
             logging.getLogger("kernel_sidecar").setLevel(log_level)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ from jupyter_client import AsyncKernelClient, manager
 from kernel_sidecar.client import KernelSidecarClient
 from kernel_sidecar.log_utils import setup_logging
 
+logger = logging.getLogger(__name__)
+
 
 @pytest.fixture(scope="session")
 def event_loop():
@@ -37,6 +39,7 @@ async def ipykernel() -> dict:
         try:
             yield kc.get_connection_info()
         finally:
+            logger.critical("Shutting down ipykernel")
             await km.shutdown_kernel()
 
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -154,12 +154,13 @@ async def test_execute_error(kernel: KernelSidecarClient):
     handler = DebugHandler()
     action = kernel.execute_request(code="1 / 0", handlers=[handler])
     await action
-    assert handler.counts == {
-        "status": 2,
-        "execute_input": 1,
-        "error": 1,
-        "execute_reply": 1,
-    }
+    # sometimes execute_reply doesn't show up in CI tests, maybe in prod deploys too? We have logic
+    # to resolve the asyncio.Event when error is seen. So here just assert error is in the counts,
+    # but don't assert execute_reply.
+    assert handler.counts["status"] == 2
+    assert handler.counts["execute_input"] == 1
+    assert handler.counts["error"] == 1
+
     error: messages.Error = handler.get_last_msg("error")
     assert isinstance(error, messages.Error)
     assert error.content.ename == "ZeroDivisionError"

--- a/tests/test_output_handler.py
+++ b/tests/test_output_handler.py
@@ -124,7 +124,7 @@ async def test_error_in_output(kernel: KernelSidecarClient):
     # So 3 actions: two execute_request, one comm_msg
     assert len(kernel.actions) == 3
     # Await all actions including the comm_msg syncing output widget state to Kernel
-    await asyncio.wait_for(await asyncio.gather(*kernel.actions.values()), timeout=10)
+    await asyncio.wait_for(asyncio.gather(*kernel.actions.values()), timeout=10)
 
     assert builder.nb.cells[0].outputs[0].output_type == "execute_result"
     assert builder.nb.cells[0].outputs[0].data["text/plain"] == "Output()"


### PR DESCRIPTION
closes #11 and https://github.com/kafonek/kernel-sidecar/issues/10

The problem was that sometimes `execute_reply` messages never came back from the Kernel. It was very flaky, and I think I only saw it _in CI_ and for the `test_error_in_output` test, which raises an error inside an Output widget context manager. I can't speculate as to an `execute_reply` wouldn't come back, but a workaround is to treat seeing an `error` as akin to the "complete reply" message, since no other messages are going to come in after `error` (besides Kernel going to status idle).