### PR TITLE
add tail option in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `--tail` flag on CLI
 
 ## [0.5.1] - 2023-04-05
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Options:
   --debug / --no-debug            Turn on DEBUG logging  [default: no-debug]
   --execute TEXT                  Execute code string instead of sending
                                   kernel info request
+  --tail / --no-tail              Continue tailing ZMQ after connecting or
+                                  executing code  [default: no-tail]
   --install-completion [bash|zsh|fish|powershell|pwsh]
                                   Install completion for the specified shell.
   --show-completion [bash|zsh|fish|powershell|pwsh]

--- a/src/kernel_sidecar/cli.py
+++ b/src/kernel_sidecar/cli.py
@@ -58,7 +58,9 @@ def main(
     execute: Optional[str] = typer.Option(
         default=None, help="Execute code string instead of sending kernel info request"
     ),
-    tail: Optional[bool] = False,
+    tail: Optional[bool] = typer.Option(
+        default=False, help="Continue tailing ZMQ after connecting or executing code"
+    ),
 ):
     if debug:
         setup_logging(log_level=logging.DEBUG)

--- a/src/kernel_sidecar/cli.py
+++ b/src/kernel_sidecar/cli.py
@@ -38,12 +38,15 @@ async def execute_code(connection_info: KernelConnectionInfo, code: str):
         await kernel.execute_request(code=code, handlers=[OutputHandler()])
 
 
-async def connect(connection_info: KernelConnectionInfo):
+async def connect(connection_info: KernelConnectionInfo, tail: bool):
     async with KernelSidecarClient(connection_info) as kernel:
         handler = DebugHandler()
         await kernel.kernel_info_request(handlers=[handler])
         kernel_info: messages.KernelInfoReply = handler.get_last_msg("kernel_info_reply")
         logger.info(pprint.pformat(kernel_info.content.dict()))
+        if tail:
+            while True:
+                await asyncio.sleep(0.01)
 
 
 @app.command()
@@ -55,6 +58,7 @@ def main(
     execute: Optional[str] = typer.Option(
         default=None, help="Execute code string instead of sending kernel info request"
     ),
+    tail: Optional[bool] = False,
 ):
     if debug:
         setup_logging(log_level=logging.DEBUG)
@@ -65,7 +69,7 @@ def main(
     if execute:
         asyncio.run(execute_code(connection_info, execute))
     else:
-        asyncio.run(connect(connection_info))
+        asyncio.run(connect(connection_info, tail=tail))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`sidecar -f <connection-info.json> --debug --tail` is useful to watch zmq messages emitted by the kernel when something else is sending in commands (like `jupyter notebook` / `jupyter lab` kernels and interacting from the UI)