### PR TITLE
remove `pprint.pformat` in debug logs

### DIFF
--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -376,7 +376,7 @@ class KernelSidecarClient:
                 msg_type = raw_msg.get("msg_type", "")
                 logger.debug(
                     f"Message {msg_type} on {channel_name}",
-                    extra=raw_msg,
+                    extra={"body": pprint.pformat(raw_msg), "channel": channel_name},
                 )
                 self.mq.put_nowait(raw_msg)
             except asyncio.CancelledError:

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -171,7 +171,7 @@ class KernelSidecarClient:
             self.actions[action.msg_id] = action
             logger.debug(
                 f"Sent {action.request.header.msg_type} to kernel",
-                extra=action.request.dict(),
+                extra={"body": action.request.dict()},
             )
         except Exception as e:
             logger.exception("Error sending message", extra={"body": action.request.dict()})

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -376,7 +376,7 @@ class KernelSidecarClient:
                 msg_type = raw_msg.get("msg_type", "")
                 logger.debug(
                     f"Message {msg_type} on {channel_name}",
-                    extra={"body": pprint.pformat(raw_msg), "channel": channel_name},
+                    extra={"body": raw_msg, "channel": channel_name},
                 )
                 self.mq.put_nowait(raw_msg)
             except asyncio.CancelledError:

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -376,7 +376,7 @@ class KernelSidecarClient:
                 msg_type = raw_msg.get("msg_type", "")
                 logger.debug(
                     f"Message {msg_type} on {channel_name}",
-                    extra={"body": pprint.pformat(raw_msg), "channel": channel_name},
+                    extra=raw_msg,
                 )
                 self.mq.put_nowait(raw_msg)
             except asyncio.CancelledError:
@@ -454,9 +454,7 @@ class KernelSidecarClient:
         # Make a noisy warning here because it will potentially break awaiting actions, such as
         # if kernel_info_reply ends up unparseable because LanguageInfo payload is slightly off or
         # something, then await sidecar.kernel_info_request() will never resolve
-        logger.warning(
-            "Unparseable message", extra={"body": raw_msg, "error": error}
-        )
+        logger.warning("Unparseable message", extra={"body": raw_msg, "error": error})
 
     async def handle_zmq_disconnect(self, channel_name: str):
         pass

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -17,7 +17,6 @@ assert handler.counts == {"status": 2, "kernel_info_reply": 1}
 
 import asyncio
 import logging
-import pprint
 from typing import Awaitable, Callable, List, Optional, Type
 
 import pydantic

--- a/src/kernel_sidecar/client.py
+++ b/src/kernel_sidecar/client.py
@@ -24,13 +24,12 @@ import pydantic
 import zmq
 from jupyter_client import AsyncKernelClient, KernelConnectionInfo
 from jupyter_client.channels import ZMQSocketChannel
-from zmq.asyncio import Context
-from zmq.utils.monitor import recv_monitor_message
-
 from kernel_sidecar import actions
 from kernel_sidecar.comms import CommHandler, CommManager, WidgetHandler
 from kernel_sidecar.handlers.base import Handler
 from kernel_sidecar.models import messages, requests
+from zmq.asyncio import Context
+from zmq.utils.monitor import recv_monitor_message
 
 logger = logging.getLogger(__name__)
 
@@ -173,7 +172,7 @@ class KernelSidecarClient:
             self.actions[action.msg_id] = action
             logger.debug(
                 f"Sent {action.request.header.msg_type} to kernel",
-                extra={"body": pprint.pformat(action.request.dict())},
+                extra=action.request.dict(),
             )
         except Exception as e:
             logger.exception("Error sending message", extra={"body": action.request.dict()})
@@ -456,7 +455,7 @@ class KernelSidecarClient:
         # if kernel_info_reply ends up unparseable because LanguageInfo payload is slightly off or
         # something, then await sidecar.kernel_info_request() will never resolve
         logger.warning(
-            "Unparseable message", extra={"body": pprint.pformat(raw_msg), "error": error}
+            "Unparseable message", extra={"body": raw_msg, "error": error}
         )
 
     async def handle_zmq_disconnect(self, channel_name: str):

--- a/src/kernel_sidecar/handlers/output.py
+++ b/src/kernel_sidecar/handlers/output.py
@@ -106,10 +106,9 @@ class OutputHandler(Handler):
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
+        await self.add_content(msg.content)
         if msg.content.display_id:
             await self.sync_display_data(msg.content)
-        else:
-            await self.add_content(msg.content)
 
     async def handle_update_display_data(self, msg: messages.UpdateDisplayData):
         await self.sync_display_data(msg.content)

--- a/src/kernel_sidecar/handlers/output.py
+++ b/src/kernel_sidecar/handlers/output.py
@@ -61,6 +61,7 @@ class OutputHandler(Handler):
         pass
 
     async def add_content(self, content: ContentType):
+        logger.debug("add_content")
         if self.output_widget_contexts:  # inside a "with out:" Output widget context
             handler: WidgetHandler = self.output_widget_contexts[0]
             handler.state["outputs"].append(content)
@@ -70,6 +71,7 @@ class OutputHandler(Handler):
             await self.add_cell_content(content)
 
     async def clear_content(self):
+        logger.debug("clear_content")
         if self.output_widget_contexts:
             handler: WidgetHandler = self.output_widget_contexts[0]
             handler.state["outputs"] = []
@@ -79,47 +81,56 @@ class OutputHandler(Handler):
             await self.clear_cell_content()
 
     async def sync_output_widget_state(self, handler: WidgetHandler):
+        logger.debug("sync_output_widget_state")
         self.client.comm_msg_request(
             comm_id=handler.comm_id,
             data={"method": "update", "state": {"outputs": handler.state["outputs"]}},
         )
 
     async def handle_stream(self, msg: messages.Stream):
+        logger.debug("handle_stream")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_execute_result(self, msg: messages.ExecuteResult):
+        logger.debug("handle_execute_result")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_error(self, msg: messages.Error):
+        logger.debug("handle_error")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_display_data(self, msg: messages.DisplayData):
+        logger.debug("handle_display_data")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
-        await self.add_content(msg.content)
         if msg.content.display_id:
             await self.sync_display_data(msg.content)
+        else:
+            await self.add_content(msg.content)
 
     async def handle_update_display_data(self, msg: messages.UpdateDisplayData):
+        logger.debug("handle_update_display_data")
         await self.sync_display_data(msg.content)
 
     async def handle_clear_output(self, msg: messages.ClearOutput):
+        logger.debug("handle_clear_output")
         if msg.content.wait:
             self.clear_on_next_output = True
         else:
             await self.clear_content()
 
     async def handle_comm_msg(self, msg: messages.CommMsg):
+        logger.debug("handle_comm_msg")
         # Exit early if:
         #  - we don't recognize this comm id
         #  - It's not a comm for an Output Widget

--- a/src/kernel_sidecar/handlers/output.py
+++ b/src/kernel_sidecar/handlers/output.py
@@ -61,7 +61,6 @@ class OutputHandler(Handler):
         pass
 
     async def add_content(self, content: ContentType):
-        logger.critical("add_content")
         if self.output_widget_contexts:  # inside a "with out:" Output widget context
             handler: WidgetHandler = self.output_widget_contexts[0]
             handler.state["outputs"].append(content)
@@ -71,7 +70,6 @@ class OutputHandler(Handler):
             await self.add_cell_content(content)
 
     async def clear_content(self):
-        logger.critical("clear_content")
         if self.output_widget_contexts:
             handler: WidgetHandler = self.output_widget_contexts[0]
             handler.state["outputs"] = []
@@ -81,35 +79,30 @@ class OutputHandler(Handler):
             await self.clear_cell_content()
 
     async def sync_output_widget_state(self, handler: WidgetHandler):
-        logger.critical("sync_output_widget_state")
         self.client.comm_msg_request(
             comm_id=handler.comm_id,
             data={"method": "update", "state": {"outputs": handler.state["outputs"]}},
         )
 
     async def handle_stream(self, msg: messages.Stream):
-        logger.critical("handle_stream")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_execute_result(self, msg: messages.ExecuteResult):
-        logger.critical("handle_execute_result")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_error(self, msg: messages.Error):
-        logger.critical("handle_error")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_display_data(self, msg: messages.DisplayData):
-        logger.critical("handle_display_data")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
@@ -119,18 +112,15 @@ class OutputHandler(Handler):
             await self.add_content(msg.content)
 
     async def handle_update_display_data(self, msg: messages.UpdateDisplayData):
-        logger.critical("handle_update_display_data")
         await self.sync_display_data(msg.content)
 
     async def handle_clear_output(self, msg: messages.ClearOutput):
-        logger.critical("handle_clear_output")
         if msg.content.wait:
             self.clear_on_next_output = True
         else:
             await self.clear_content()
 
     async def handle_comm_msg(self, msg: messages.CommMsg):
-        logger.critical("handle_comm_msg")
         # Exit early if:
         #  - we don't recognize this comm id
         #  - It's not a comm for an Output Widget

--- a/src/kernel_sidecar/handlers/output.py
+++ b/src/kernel_sidecar/handlers/output.py
@@ -61,7 +61,7 @@ class OutputHandler(Handler):
         pass
 
     async def add_content(self, content: ContentType):
-        logger.debug("add_content")
+        logger.critical("add_content")
         if self.output_widget_contexts:  # inside a "with out:" Output widget context
             handler: WidgetHandler = self.output_widget_contexts[0]
             handler.state["outputs"].append(content)
@@ -71,7 +71,7 @@ class OutputHandler(Handler):
             await self.add_cell_content(content)
 
     async def clear_content(self):
-        logger.debug("clear_content")
+        logger.critical("clear_content")
         if self.output_widget_contexts:
             handler: WidgetHandler = self.output_widget_contexts[0]
             handler.state["outputs"] = []
@@ -81,35 +81,35 @@ class OutputHandler(Handler):
             await self.clear_cell_content()
 
     async def sync_output_widget_state(self, handler: WidgetHandler):
-        logger.debug("sync_output_widget_state")
+        logger.critical("sync_output_widget_state")
         self.client.comm_msg_request(
             comm_id=handler.comm_id,
             data={"method": "update", "state": {"outputs": handler.state["outputs"]}},
         )
 
     async def handle_stream(self, msg: messages.Stream):
-        logger.debug("handle_stream")
+        logger.critical("handle_stream")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_execute_result(self, msg: messages.ExecuteResult):
-        logger.debug("handle_execute_result")
+        logger.critical("handle_execute_result")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_error(self, msg: messages.Error):
-        logger.debug("handle_error")
+        logger.critical("handle_error")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
         await self.add_content(msg.content)
 
     async def handle_display_data(self, msg: messages.DisplayData):
-        logger.debug("handle_display_data")
+        logger.critical("handle_display_data")
         if self.clear_on_next_output:
             await self.clear_content()
             self.clear_on_next_output = False
@@ -119,18 +119,18 @@ class OutputHandler(Handler):
             await self.add_content(msg.content)
 
     async def handle_update_display_data(self, msg: messages.UpdateDisplayData):
-        logger.debug("handle_update_display_data")
+        logger.critical("handle_update_display_data")
         await self.sync_display_data(msg.content)
 
     async def handle_clear_output(self, msg: messages.ClearOutput):
-        logger.debug("handle_clear_output")
+        logger.critical("handle_clear_output")
         if msg.content.wait:
             self.clear_on_next_output = True
         else:
             await self.clear_content()
 
     async def handle_comm_msg(self, msg: messages.CommMsg):
-        logger.debug("handle_comm_msg")
+        logger.critical("handle_comm_msg")
         # Exit early if:
         #  - we don't recognize this comm id
         #  - It's not a comm for an Output Widget


### PR DESCRIPTION
Some large messages may blow up memory usage