### PR TITLE
make `transient` optional

### DIFF
--- a/src/kernel_sidecar/models/messages.py
+++ b/src/kernel_sidecar/models/messages.py
@@ -275,7 +275,7 @@ class DisplayDataContent(BaseModel):
     output_type: Literal["display_data"] = "display_data"
     data: dict  # mimebundle
     metadata: dict = Field(default_factory=dict)
-    transient: DisplayDataTransient
+    transient: Optional[DisplayDataTransient] = None
 
     class Config:
         # including transient in a saved .json file would be invalid jupyter spec, so by default
@@ -287,7 +287,8 @@ class DisplayDataContent(BaseModel):
 
     @property
     def display_id(self) -> Optional[str]:
-        return self.transient.display_id
+        if self.transient:
+            return self.transient.display_id
 
 
 class DisplayData(MessageBase):
@@ -306,11 +307,12 @@ class UpdateDisplayDataContent(DisplayDataContent):
     output_type: Literal["update_display_data"] = "update_display_data"
     data: dict  # mimebundle
     metadata: dict = Field(default_factory=dict)
-    transient: DisplayDataTransient
+    transient: Optional[DisplayDataTransient] = None
 
     @property
     def display_id(self) -> Optional[str]:
-        return self.transient.display_id
+        if self.transient:
+            return self.transient.display_id
 
 
 class UpdateDisplayData(MessageBase):


### PR DESCRIPTION
From some ValidationErrors seen using an R kernel:
```python
error=ValidationError(model="ParsingModel[Annotated[Union[kernel_sidecar.models.messages.Status, kernel_sidecar.models.messages.ExecuteInput, kernel_sidecar.models.messages.ExecuteResult, kernel_sidecar.models.messages.Stream, kernel_sidecar.models.messages.DisplayData, kernel_sidecar.models.messages.UpdateDisplayData, kernel_sidecar.models.messages.ExecuteReply, kernel_sidecar.models.messages.Error, kernel_sidecar.models.messages.CommOpen, kernel_sidecar.models.messages.CommMsg, kernel_sidecar.models.messages.CommClose, kernel_sidecar.models.messages.CommInfoReply, kernel_sidecar.models.messages.KernelInfoReply, kernel_sidecar.models.messages.InspectReply, kernel_sidecar.models.messages.CompleteReply, kernel_sidecar.models.messages.HistoryReply, kernel_sidecar.models.messages.InterruptReply, kernel_sidecar.models.messages.Shutdown, kernel_sidecar.models.messages.ClearOutput, kernel_sidecar.models.messages.DebugReply, kernel_sidecar.models.messages.InputRequest], FieldInfo(default=PydanticUndefined, discriminator='msg_type', extra={})]]", errors=[{'loc': ('__root__', 'DisplayData', 'content', 'transient'), 'msg': 'field required', 'type': 'value_error.missing'}])
```