### PR TITLE
Squash streaming stdout cell outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Consecutive streaming outputs on `stdout` in a cell output context (vice widget context) will be "squashed" into a single output before passed to `.add_cell_content`
 
 ## [0.5.5] - 2023-04-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Consecutive streaming outputs on `stdout` in a cell output context (vice widget context) will be "squashed" into a single output before passed to `.add_cell_content`
+- Add option in `OutputHandler` to squash streaming outputs on `stdout` in a cell output context (vice widget context) in order to create a single output before entering `.add_cell_content`
 
 ## [0.5.5] - 2023-04-26
 ### Fixed

--- a/src/kernel_sidecar/handlers/output.py
+++ b/src/kernel_sidecar/handlers/output.py
@@ -96,6 +96,9 @@ class OutputHandler(Handler):
             await self.sync_output_widget_state(handler)
             await self.clear_output_widget_content(handler)
         else:
+            # clear out squashed stored stream content if we're clearing
+            if self.stored_stream_content:
+                self.stored_stream_content = None
             await self.clear_cell_content()
 
     async def sync_output_widget_state(self, handler: WidgetHandler):

--- a/src/kernel_sidecar/nb_builder.py
+++ b/src/kernel_sidecar/nb_builder.py
@@ -100,8 +100,18 @@ class SimpleOutputHandler(OutputHandler):
     to replace the Output widget mimetype with actual output content.
     """
 
-    def __init__(self, client: KernelSidecarClient, cell_id: str, builder: NotebookBuilder):
-        super().__init__(client, cell_id)
+    def __init__(
+        self,
+        client: KernelSidecarClient,
+        cell_id: str,
+        builder: NotebookBuilder,
+        squash_streaming_output: bool = False,
+    ):
+        super().__init__(
+            client=client,
+            cell_id=cell_id,
+            squash_streaming_output=squash_streaming_output,
+        )
         self.builder = builder
 
     async def add_cell_content(self, content: ContentType):


### PR DESCRIPTION
Optional flag for squashing streaming `stdout` cell output into a single output message